### PR TITLE
Add arg to run the qautomata with a state file

### DIFF
--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -2,8 +2,12 @@ use crate::engine;
 use clap::Args;
 
 #[derive(Args, Debug)]
-pub struct RunCmd {}
+pub struct RunCmd {
+    // the starting state file
+    #[clap(value_name = "STATE_FILE", index = 1)]
+    state_file: Option<String>,
+}
 
-pub fn run(_cmd: &RunCmd) {
-    engine::run();
+pub fn run(args: &RunCmd) {
+    engine::run(&args.state_file);
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,7 +1,19 @@
 use crate::gui;
 use crate::universe::types::*;
 
-pub fn run() {
-    let universe = Universe::new_from_files("./fixtures/state_2_adjacent_cells.json");
+pub fn run(state_file: &Option<String>) {
+    // If there is a state file, use it as the starting state
+    // Use an empty universe otherwise (unique configuration with no living cell)
+    let universe = match state_file {
+        None => Universe::new(),
+        Some(s) => match Universe::new_from_files(s) {
+            Ok(u) => u,
+            Err(err) => {
+                println!("Error: failed to load state file: {err}");
+                return;
+            }
+        },
+    };
+
     gui::run(universe);
 }

--- a/src/universe/files.rs
+++ b/src/universe/files.rs
@@ -1,8 +1,9 @@
 use super::types;
 use std::fs;
+use std::io::Error;
 
-pub fn get_state_from_file(state_file: &str) -> types::State {
-    let content = fs::read_to_string(state_file).expect("Error while reading file");
-    let state: types::State = serde_json::from_str(&content).unwrap();
-    state
+pub fn get_state_from_file(state_file: &str) -> Result<types::State, Error> {
+    let content = fs::read_to_string(state_file)?;
+    let state: types::State = serde_json::from_str(&content)?;
+    Ok(state)
 }

--- a/src/universe/types.rs
+++ b/src/universe/types.rs
@@ -53,11 +53,18 @@ pub struct Universe {
 
 impl Universe {
     pub fn new() -> Self {
+        // Unique configuration with no living cell
+        let configuration = Configuration {
+            amplitude: Complex::new(1., 0.),
+            living_cells: HashMap::new(),
+        };
+        let state = vec![configuration];
+        let rules = get_test_rules();
         Self {
-            state: State::new(),
+            state,
             combined_state: HashMap::new(),
             is_even_step: true,
-            rules: [[Complex::new(0.0, 0.0); 16]; 16],
+            rules,
         }
     }
 

--- a/src/universe/types.rs
+++ b/src/universe/types.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::collections::HashMap;
 use std::f64::consts::PI;
+use std::io::Error;
 
 #[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct Coordinates {
@@ -60,15 +61,15 @@ impl Universe {
         }
     }
 
-    pub fn new_from_files(state_file: &str) -> Self {
-        let state = files::get_state_from_file(state_file);
+    pub fn new_from_files(state_file: &str) -> Result<Self, Error> {
+        let state = files::get_state_from_file(state_file)?;
         let rules = get_test_rules();
-        Self {
+        Ok(Self {
             state,
             combined_state: HashMap::new(),
-            rules,
             is_even_step: true,
-        }
+            rules,
+        })
     }
 }
 


### PR DESCRIPTION
Add arg to run the qautomata with a state file.
If no state file is provided, run the qautomata with an empty universe (unique configuration with no living cell).
Solves #35