### PR TITLE
Deploy on GitHub pages

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,7 +25,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: ui
+        working-directory: web
 
     steps:
       - name: Checkout
@@ -44,7 +44,7 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           # Upload entire repository
-          path: ui/dist
+          path: web/dist
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - deploy-on-github-pages #to remove before merge
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,51 @@
+name: Deploy Github pages
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+      - deploy-on-github-pages #to remove before merge
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy-to-github-pages:
+    name: Deploy to GitHub Pages
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ui
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install and Build
+        run: |
+          npm install
+          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          npm run build
+          rm -rf node_modules
+          rm -rf src
+          rm -rf target
+
+      - name: Use the Upload Artifact GitHub Action
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: ui/dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This PR deploys qautomata using GitHub Pages on https://git-math.github.io/qautomata.

Should be reviewed after #42 is merged and the PR is rebased on top of main