### PR TITLE
Improve UI

### DIFF
--- a/ui/src/sketch.rs
+++ b/ui/src/sketch.rs
@@ -68,6 +68,10 @@ fn update_ui(model: &mut Model) {
                     }
                     if ui.button("Step").clicked() {
                         model.universe.step();
+
+                        if model.universe.state.len() > model.universe_measure_max {
+                            model.universe.measure();
+                        }
                     }
                     if ui.button("Measure").clicked() {
                         model.universe.measure();
@@ -172,11 +176,7 @@ fn update(app: &App, model: &mut Model, _update: Update) {
                 }
             }
         }
-        State::Paused => {
-            if model.universe.state.len() > model.universe_measure_max {
-                model.universe.measure();
-            }
-        }
+        State::Paused => (),
     }
 
     update_ui(model);

--- a/ui/src/sketch.rs
+++ b/ui/src/sketch.rs
@@ -62,7 +62,6 @@ fn update_ui(model: &mut Model) {
                         model.selected_configuration = None;
                         model.universe =
                             Universe::new_from_files(model.universe_file.as_str()).unwrap();
-                        model.universe.step();
                     }
                     if ui.button("Run").clicked() {
                         model.state = State::Running;

--- a/ui/src/sketch.rs
+++ b/ui/src/sketch.rs
@@ -165,11 +165,11 @@ fn update(app: &App, model: &mut Model, _update: Update) {
             if app.elapsed_frames() % frame_to_skip != 0 {
                 return;
             } else {
+                model.universe.step();
+
                 if model.universe.state.len() > model.universe_measure_max {
                     model.universe.measure();
                 }
-
-                model.universe.step();
             }
         }
         State::Paused => {

--- a/ui/src/sketch.rs
+++ b/ui/src/sketch.rs
@@ -71,6 +71,7 @@ fn update_ui(model: &mut Model) {
 
                         if model.universe.state.len() > model.universe_measure_max {
                             model.universe.measure();
+                            model.selected_configuration = None;
                         }
                     }
                     if ui.button("Measure").clicked() {
@@ -173,6 +174,7 @@ fn update(app: &App, model: &mut Model, _update: Update) {
 
                 if model.universe.state.len() > model.universe_measure_max {
                     model.universe.measure();
+                    model.selected_configuration = None;
                 }
             }
         }


### PR DESCRIPTION
Minor improvements to the UI:

- Start at step 0 instead of step 1 when using the "Reset" button
- When running we do a measure if needed after computing the step (instead of before) so that the number of configuration never goes over the max
- When the game is Paused we only check for measure if the "Step" button is clicked
- Always unselect configurations when a measure is done